### PR TITLE
Feat: signup 페이지 수정 및 비밀번호 찾기 페이지 추가

### DIFF
--- a/src/app/forget/reset/page.tsx
+++ b/src/app/forget/reset/page.tsx
@@ -1,0 +1,7 @@
+import ResetPage from '@/pages/reset/ui/reset-page';
+
+function page() {
+  return <ResetPage />;
+}
+
+export default page;

--- a/src/entities/login/ui/login-fourth-section.tsx
+++ b/src/entities/login/ui/login-fourth-section.tsx
@@ -29,7 +29,7 @@ function LoginFourthSection() {
           <Button
             asChild
             type="button"
-            variant="blackGradient"
+            variant="bgBlackGradient"
             className="h-[55px] w-[600px] text-sm font-bold"
           >
             <Link href="/signup/vendor">

--- a/src/features/forget/api/forgetPost.tsx
+++ b/src/features/forget/api/forgetPost.tsx
@@ -1,0 +1,19 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+async function forgetPost(_prevState: void, formData: FormData): Promise<void> {
+  const email = formData?.get('email') as string;
+  const company = formData?.get('company') as string;
+
+  if (!email || email.trim().length === 0) {
+    return;
+  }
+  if (!company || company.trim().length === 0) {
+    return;
+  }
+
+  redirect('/forget/reset');
+}
+
+export default forgetPost;

--- a/src/features/forget/ui/forget-form.tsx
+++ b/src/features/forget/ui/forget-form.tsx
@@ -5,15 +5,12 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Input from '@/shared/ui/input';
 import SignupForm from '@/shared/ui/signup-form';
-import loginPost from '@/features/login/api/loginPost';
-import { Button } from '@/shared/ui/button';
-import CustomModal from '@/shared/ui/custommodal';
-import { useState } from 'react';
+import forgetPost from '@/features/forget/api/forgetPost';
+import ErrorMessage from '@/shared/ui/error-message';
 
 const schema = z.object({
   company: z.string().min(1, '기업명(사업자명) 입력해주세요.'),
-  email: z.string().min(1, '이메일 입력해주세요.'),
-  code: z.string().min(1, '인증코드 입력해주세요.'),
+  email: z.string().email('올바른 이메일 형식이 아닙니다.'),
 });
 
 type FormSchema = z.infer<typeof schema>;
@@ -24,20 +21,21 @@ type FormSchema = z.infer<typeof schema>;
 function ForgetForm() {
   const {
     register,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormSchema>({
     resolver: zodResolver(schema),
     mode: 'onChange',
   });
-  const [open, setOpen] = useState(false);
+
   return (
     <SignupForm
-      action={loginPost}
+      action={forgetPost}
       buttonProps="bg-gradient-to-t from-[#6E86FF] to-[#5B76FF] text-white w-full h-[55px] font-bold text-sm mt-4 "
-      buttonName="비밀번호 재설정하기"
+      buttonName="이메일로 비밀번호 재설정 링크 전송"
       buttonWrapperClassName="flex justify-center"
-      loadingText="인증 중.."
+      loadingText="전송 중.."
       formProps="border-0 space-y-4 w-[500px]"
+      disabled={!isValid}
     >
       <div>
         <Input
@@ -48,74 +46,19 @@ function ForgetForm() {
           placeholder="기업명(사업자명)"
           className="h-[45px] w-full bg-white indent-2 text-black"
         />
-        {errors.company && (
-          <p className="text-sm text-red-500">{errors.company.message}</p>
-        )}
+        {errors.company && <ErrorMessage message={errors.company.message} />}
       </div>
-      <div className="grid w-full grid-cols-[3fr_1fr] items-center justify-between gap-3">
-        <div>
-          <Input
-            id="email"
-            type="string"
-            {...register('email')}
-            name="email"
-            placeholder="이메일 입력"
-            className="h-[45px] w-full bg-white indent-2 text-black"
-          />
-          {errors.email && (
-            <p className="text-sm text-red-500">{errors.email.message}</p>
-          )}
-        </div>
-        <Button
-          type="button"
-          variant="login"
-          asChild={false}
-          onClick={() => setOpen(true)}
-          className="h-[45px] w-full rounded-sm bg-white text-sm font-bold text-[#5B76FF] shadow-sm"
-        >
-          인증코드 전송
-        </Button>
-      </div>
-      <div className="grid w-full grid-cols-[3fr_1fr] items-center justify-between gap-3">
-        <div>
-          <Input
-            id="code"
-            type="string"
-            {...register('code')}
-            name="code"
-            placeholder="인증코드 입력"
-            className="h-[45px] w-full bg-white indent-2 text-black"
-          />
-          {errors.code && (
-            <p className="text-sm text-red-500">{errors.code.message}</p>
-          )}
-        </div>
-        <Button
-          type="button"
-          variant="login"
-          asChild={false}
-          onClick={() => {}}
-          className="h-[45px] w-full rounded-sm bg-white text-sm font-bold text-[#5B76FF] shadow-sm"
-        >
-          인증하기
-        </Button>
-        <CustomModal
-          open={open}
-          setOpen={setOpen}
-          title="인증코드가 전송되었습니다."
-          contentProps="border-0 space-y-1 w-[500px]"
-          titleProps="text-2xl font-bold text-center text-[#5B76FF]"
-          subTitleDescription="메일에서 6자리 코드를 확인해주세요"
-        >
-          <Button
-            onClick={() => setOpen(false)}
-            type="button"
-            asChild={false}
-            className="h-[50px] bg-gradient-to-t from-[#6E86FF] to-[#5B76FF] text-white"
-          >
-            확인
-          </Button>
-        </CustomModal>
+
+      <div>
+        <Input
+          id="email"
+          type="string"
+          {...register('email')}
+          name="email"
+          placeholder="이메일 입력"
+          className="h-[45px] w-full bg-white indent-2 text-black"
+        />
+        {errors.email && <ErrorMessage message={errors.email.message} />}
       </div>
     </SignupForm>
   );

--- a/src/features/home/ui/main-section-buttons.tsx
+++ b/src/features/home/ui/main-section-buttons.tsx
@@ -3,16 +3,32 @@ import { Button } from '@/shared/ui/button';
 function MainSectionButtons() {
   return (
     <div className="mt-10 grid w-[500px] grid-cols-2 gap-8">
-      <Button variant="textBlue" className="h-[120px] w-full" asChild={false}>
+      <Button
+        variant="textBlue"
+        className="h-[110px] w-full rounded-xl shadow-md"
+        asChild={false}
+      >
         CRM(고객 정보 및 관계 관리)
       </Button>
-      <Button variant="textBlue" className="h-[120px] w-full" asChild={false}>
+      <Button
+        variant="textBlue"
+        className="h-[110px] w-full rounded-xl shadow-md"
+        asChild={false}
+      >
         ERP(전사 자원 관리)
       </Button>
-      <Button variant="textBlue" className="h-[120px] w-full" asChild={false}>
+      <Button
+        variant="textBlue"
+        className="h-[110px] w-full rounded-xl shadow-md"
+        asChild={false}
+      >
         HR(성과 및 조직 관리)
       </Button>
-      <Button variant="textBlue" className="h-[120px] w-full" asChild={false}>
+      <Button
+        variant="textBlue"
+        className="h-[110px] w-full rounded-xl shadow-md"
+        asChild={false}
+      >
         HRM(인사 관리)
       </Button>
     </div>

--- a/src/features/reset/api/resetPost.tsx
+++ b/src/features/reset/api/resetPost.tsx
@@ -1,0 +1,15 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+async function resetPost(_prevState: void, formData: FormData): Promise<void> {
+  const password = formData?.get('password') as string;
+  const confirmPassword = formData?.get('confirmPassword') as string;
+  if (!password || password.trim().length === 0) {
+    return;
+  }
+
+  redirect('/login');
+}
+
+export default resetPost;

--- a/src/features/reset/ui/reset-form.tsx
+++ b/src/features/reset/ui/reset-form.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Input from '@/shared/ui/input';
+import SignupForm from '@/shared/ui/signup-form';
+import { Button } from '@/shared/ui/button';
+import { useState } from 'react';
+import { CheckCircle } from 'lucide-react';
+import ErrorMessage from '@/shared/ui/error-message';
+import resetPost from '../api/resetPost';
+
+const passwordRegex = /^(?=.*[!@#])[A-Za-z\d!@#]{8,16}$/;
+
+const schema = z.object({
+  password: z
+    .string()
+    .min(8)
+    .max(16)
+    .regex(
+      passwordRegex,
+      '비밀번호는 특수문자(!@#)를 1개 이상 포함해야 합니다.',
+    ),
+  confirmPassword: z.string().min(1, '비밀번호 확인 입력해주세요.'),
+});
+
+type FormSchema = z.infer<typeof schema>;
+
+function ResetForm() {
+  const {
+    register,
+    formState: { errors, isValid },
+    setError,
+    setValue,
+    getValues,
+    watch,
+  } = useForm<FormSchema>({
+    resolver: zodResolver(schema),
+    mode: 'onChange',
+  });
+
+  const [matchSuccess, setMatchSuccess] = useState(false);
+
+  const handleConfirmClick = () => {
+    const { password, confirmPassword } = getValues();
+    if (password !== confirmPassword) {
+      setError('confirmPassword', {
+        type: 'manual',
+        message: '비밀번호를 다시 확인해주세요.',
+      });
+      setValue('confirmPassword', '');
+      setMatchSuccess(false);
+    } else {
+      setMatchSuccess(true);
+    }
+  };
+  const confirmValid = watch('confirmPassword');
+  return (
+    <SignupForm
+      action={resetPost}
+      buttonProps="bg-gradient-to-t from-[#6E86FF] to-[#5B76FF] text-white w-full h-[55px] font-bold text-sm mt-4"
+      buttonName="비밀번호 재설정 완료"
+      buttonWrapperClassName="flex justify-center"
+      loadingText="재설정 중.."
+      formProps="border-0 space-y-4 w-[500px]"
+      disabled={!isValid || !matchSuccess}
+    >
+      <div>
+        <Input
+          id="password"
+          type="password"
+          {...register('password')}
+          name="password"
+          placeholder="비밀번호 입력 *8~16자리 입력, 특수기호(!@#) 1개 포함"
+          className="h-[45px] w-full bg-white indent-2 text-black"
+        />
+        {errors.password && <ErrorMessage message={errors.password.message} />}
+      </div>
+
+      <div>
+        <div className="grid grid-cols-[3fr_1fr] items-center gap-2">
+          <Input
+            placeholder="비밀번호 확인"
+            className="h-[45px] w-full bg-white indent-2"
+            type="password"
+            {...register('confirmPassword')}
+          />
+          <Button
+            type="button"
+            onClick={handleConfirmClick}
+            variant="textBlue"
+            asChild={false}
+            disabled={!isValid || confirmValid.length < 8}
+            className="h-[45px] text-sm text-[#7A7A7A] shadow-sm"
+          >
+            확인
+            {matchSuccess && <CheckCircle className="h-5 w-5 text-green-500" />}
+          </Button>
+        </div>
+
+        {errors.confirmPassword && (
+          <ErrorMessage message={errors.confirmPassword.message} />
+        )}
+      </div>
+    </SignupForm>
+  );
+}
+
+export default ResetForm;

--- a/src/features/signup/api/useSendEmail.tsx
+++ b/src/features/signup/api/useSendEmail.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+// 내부 state 추가
+
+function useSendEmail() {
+  const [timer, setTimer] = useState(0); // 남은 시간 (초 단위)
+  const [isCounting, setIsCounting] = useState(false);
+
+  // 타이머 감소 로직
+  useEffect(() => {
+    let countdown: NodeJS.Timeout;
+    if (isCounting && timer > 0) {
+      countdown = setTimeout(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+    } else if (timer === 0) {
+      setIsCounting(false);
+    }
+    return () => clearTimeout(countdown);
+  }, [isCounting, timer]);
+
+  // 버튼 클릭 핸들러
+  const handleSendEmail = () => {
+    // TODO: 이메일 전송 API 요청 (원한다면 추가)
+    setTimer(180); // 3분 설정
+    setIsCounting(true); // 타이머 시작
+  };
+
+  return {
+    timer,
+    isCounting,
+    handleSendEmail,
+  };
+}
+
+export default useSendEmail;

--- a/src/features/signup/ui/signup-vendor-form.tsx
+++ b/src/features/signup/ui/signup-vendor-form.tsx
@@ -6,12 +6,16 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import Input from '@/shared/ui/input';
 import SignupForm from '@/shared/ui/signup-form';
 import signupVendorPost from '@/features/signup/api/signupVendorPost';
-import Image from 'next/image';
-import { Plus } from 'lucide-react';
+import { CheckCircle } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import useFileUpload from '@/shared/model/useFileUpload';
+import { useState } from 'react';
+import ErrorMessage from '@/shared/ui/error-message';
+import useSendEmail from '../api/useSendEmail';
 
 const passwordRegex = /^(?=.*[!@#])[A-Za-z\d!@#]{8,16}$/;
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 const schema = z.object({
   company: z.string().min(1, '기업명 입력해주세요.'),
   phoneNumber: z.string().min(1, '전화번호 입력해주세요.'),
@@ -25,6 +29,7 @@ const schema = z.object({
       passwordRegex,
       '비밀번호는 특수문자(!@#)를 1개 이상 포함해야 합니다.',
     ),
+  confirmPassword: z.string(),
 });
 
 type FormSchema = z.infer<typeof schema>;
@@ -32,6 +37,10 @@ type FormSchema = z.infer<typeof schema>;
 function SignupVendorForm() {
   const {
     register,
+    setError,
+    setValue,
+    getValues,
+    watch,
     formState: { errors, isValid },
   } = useForm<FormSchema>({
     resolver: zodResolver(schema),
@@ -45,30 +54,52 @@ function SignupVendorForm() {
     handleClickFileInput,
     preview,
   } = useFileUpload();
+  const [matchSuccess, setMatchSuccess] = useState(false);
+  const [hasTriedConfirm, setHasTriedConfirm] = useState(false);
+
+  const { timer, isCounting, handleSendEmail } = useSendEmail();
+
+  const email = watch('email');
+  const isEmailValid = emailRegex.test(email);
+
+  const passValid = watch('password');
+  const isPassValid = passwordRegex.test(passValid);
+
+  const confirmValid = watch('confirmPassword');
+
+  const handleConfirmClick = () => {
+    setHasTriedConfirm(true);
+    const { password, confirmPassword } = getValues();
+    if (password !== confirmPassword) {
+      setError('confirmPassword', {
+        type: 'manual',
+        message: '비밀번호를 다시 확인해주세요.',
+      });
+      setValue('confirmPassword', '');
+      setMatchSuccess(false);
+    } else {
+      setMatchSuccess(true);
+    }
+  };
 
   return (
     <SignupForm
       action={(prevState, formData) =>
         signupVendorPost(prevState, formData, file)
       }
-      buttonProps="bg-gradient-to-r from-[#2D2D2D] to-[#404040] text-white w-full h-[60px] font-extrabold text-lg shadow-sm mb-8"
+      buttonProps="bg-gradient-to-r from-[#2D2D2D] to-[#404040] text-white w-full h-[60px] font-extrabold text-lg shadow-sm mb-8 mt-5"
       buttonName="솔루션 공급사로 파트너쉽 시작"
       loadingText="신청 중.."
-      disabled={!isValid}
+      disabled={!isValid || !matchSuccess}
     >
       <div className="w-[700px] space-y-4">
-        <div className="grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
+        <div className="mb-0 grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
           <div className="relative w-full">
             <Input
               {...register('company')}
               placeholder="기업명(사업자명)"
               className="h-[55px] w-full bg-white indent-2"
             />
-            {errors.company && (
-              <p className="absolute bottom-1 left-2 text-sm text-red-500">
-                {errors.company.message}
-              </p>
-            )}
           </div>
 
           <input
@@ -84,8 +115,9 @@ function SignupVendorForm() {
             <Button
               type="button"
               asChild={false}
+              variant="textBlue"
               onClick={handleClickFileInput}
-              className="h-[50px] w-full bg-white text-sm text-[#5B76FF] shadow-sm"
+              className="h-[50px] w-full text-sm text-[#5B76FF] shadow-sm"
             >
               사업자 등록증 첨부하기
             </Button>
@@ -97,81 +129,93 @@ function SignupVendorForm() {
             )}
           </div>
         </div>
+        {errors.company && <ErrorMessage message={errors.company.message} />}
 
         <Input
           {...register('name')}
           placeholder="담당자 성함"
-          className="h-[55px] w-full bg-white indent-2"
+          className="mt-5 mb-0 h-[55px] w-full bg-white indent-2"
         />
-        {errors.name && (
-          <p className="text-sm text-red-500">{errors.name.message}</p>
-        )}
+        {errors.name && <ErrorMessage message={errors.name.message} />}
 
         <Input
           {...register('phoneNumber')}
           placeholder="담당자 연락처(휴대폰)"
-          className="h-[55px] w-full bg-white indent-2"
+          className="mt-5 mb-0 h-[55px] w-full bg-white indent-2"
         />
         {errors.phoneNumber && (
-          <p className="text-sm text-red-500">{errors.phoneNumber.message}</p>
+          <ErrorMessage message={errors.phoneNumber.message} />
         )}
-        <div className="grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
+        <div className="mt-5 mb-0 grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
           <Input
             {...register('email')}
             placeholder="담당자 이메일 입력"
             className="h-[55px] w-full bg-white indent-2"
           />
-          {errors.email && (
-            <p className="text-sm text-red-500">{errors.email.message}</p>
-          )}
+
           <Button
             type="button"
+            disabled={isCounting || !isEmailValid}
             asChild={false}
-            onClick={() => {}}
-            className="h-[55px] w-full bg-white text-sm text-[#7A7A7A] shadow-sm"
+            variant="textBlue"
+            onClick={handleSendEmail}
+            className="h-[55px] w-full text-sm text-[#7A7A7A] shadow-sm"
           >
-            이메일 인증코드 전송
+            {isCounting
+              ? `전송 완료 (${Math.floor(timer / 60)}:${String(timer % 60).padStart(2, '0')})`
+              : '이메일 인증코드 전송'}
           </Button>
         </div>
-        <div className="grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
-          <Input
-            placeholder="인증코드 입력"
-            className="h-[55px] w-full bg-white indent-2"
-          />
-          <Button
-            type="button"
-            asChild={false}
-            onClick={() => {}}
-            className="h-[55px] w-full bg-white text-sm text-[#7A7A7A] shadow-sm"
-          >
-            인증코드 인증하기
-          </Button>
-        </div>
+        {errors.email && <ErrorMessage message={errors.email.message} />}
+        {isCounting && (
+          <div className="mt-5 grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
+            <Input
+              placeholder="인증코드 입력"
+              className="h-[55px] w-full bg-white indent-2"
+            />
+            <Button
+              type="button"
+              asChild={false}
+              variant="textBlue"
+              onClick={() => {}}
+              className="h-[55px] w-full text-sm text-[#7A7A7A] shadow-sm"
+            >
+              인증코드 인증하기
+            </Button>
+          </div>
+        )}
+
         <Input
           type="password"
           {...register('password')}
           placeholder="비밀번호 입력 *8~16자리 입력, 특수기호(!@#) 1개 포함"
-          className="h-[55px] w-full bg-white indent-2"
+          className="mt-5 mb-0 h-[55px] w-full bg-white indent-2"
         />
-        {errors.password && (
-          <p className="text-sm text-red-500">{errors.password.message}</p>
-        )}
+        {errors.password && <ErrorMessage message={errors.password.message} />}
       </div>
-      <div className="grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
+      <div className="mb-0 grid grid-cols-[3fr_1fr] items-center justify-center gap-4">
         <Input
           placeholder="비밀번호 확인"
           className="h-[55px] w-full bg-white indent-2"
+          type="password"
+          {...register('confirmPassword')}
         />
 
         <Button
           type="button"
           asChild={false}
-          onClick={() => {}}
-          className="h-[55px] w-full bg-white text-sm text-[#7A7A7A] shadow-sm"
+          disabled={!isPassValid || confirmValid.length < 8}
+          variant="textBlue"
+          onClick={handleConfirmClick}
+          className="h-[55px] w-full text-sm text-[#7A7A7A] shadow-sm"
         >
           비밀번호 확인하기
+          {matchSuccess && <CheckCircle className="h-5 w-5 text-green-500" />}
         </Button>
       </div>
+      {hasTriedConfirm && !matchSuccess && (
+        <ErrorMessage message="비밀번호를 다시 확인해주세요." />
+      )}
     </SignupForm>
   );
 }

--- a/src/pages/reset/ui/reset-page.tsx
+++ b/src/pages/reset/ui/reset-page.tsx
@@ -1,15 +1,15 @@
 import SignupLayout from '@/entities/signup/ui/signup-layout';
-import ForgetForm from '@/features/forget/ui/forget-form';
+import ResetForm from '@/features/reset/ui/reset-form';
 
-function ForgetPage() {
+function ResetPage() {
   return (
     <SignupLayout
       title="우리 기업을 위한 단 하나의 기업 솔루션 플랫폼, SOLU"
-      description="기본 정보 입력"
+      description="비밀번호 재설정"
     >
-      <ForgetForm />
+      <ResetForm />
     </SignupLayout>
   );
 }
 
-export default ForgetPage;
+export default ResetPage;

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -28,11 +28,11 @@ const buttonVariants = cva(
         vendorGray: 'bg-[#3D3D3D] text-white',
         vendorBlack: 'bg-black text-white',
         textBlue:
-          'text-[#5B76FF] bg-white hover:bg-[#e8edff] hover:text-[#3d5aff] rounded-sm',
+          'text-[#5B76FF] bg-white hover:bg-[#5B76FF] hover:text-white rounded-sm',
         bgBlackGradient:
           'bg-gradient-to-t from-[#2D2D2D] to-[#404040] text-white hover:brightness-110 hover:shadow-lg rounded-sm',
         bgBlueGradient:
-          'bg-gradient-to-t from-[#6E86FF] to-[#5B76FF] text-white hover:brightness-105 hover:shadow-md rounded-sm',
+          'bg-gradient-to-t from-[#6E86FF] to-[#5B76FF] text-white hover:brightness-110 hover:shadow-md rounded-sm',
         home: 'bg-white text-black font-bold shadow-lg rounded-xl',
         category: 'bg-[#DBE8FF] text-black',
       },

--- a/src/shared/ui/error-message.tsx
+++ b/src/shared/ui/error-message.tsx
@@ -1,0 +1,5 @@
+function ErrorMessage({ message }: { message: string | undefined }) {
+  return <p className="inset-2 mt-1 text-xs text-red-500">{message}</p>;
+}
+
+export default ErrorMessage;


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: signup 페이지 수정 및 비밀번호 찾기 페이지 추가

## 📝작업 내용

1. 회원가입 로직 리팩토링
2. 비밀번호 찾기 이메일 전송 페이지 추가
3. 비밀번호 재설정 페이지 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?